### PR TITLE
Default to ~/.ruby-version if no other is found

### DIFF
--- a/share/fry/functions/__fry_find_version_file.fish
+++ b/share/fry/functions/__fry_find_version_file.fish
@@ -7,7 +7,13 @@ function __fry_find_version_file --description 'Find .ruby-version file'
       echo -n $dir/$file
       return 0
     end
+
     set dir (dirname $dir)
+  end
+
+  if test -f $HOME/$file
+    echo -n $HOME/$file
+    return 0
   end
 
   return 1


### PR DESCRIPTION
`__fry_find_version_file` will currently exit immediately when it reaches
the root directory, `/`. It would be better to default to the version
set in `~/.ruby-version` before resetting to the system ruby.

Signed-off-by: David Celis me@davidcel.is
