### PR TITLE
ignore ls aliasing in fry-ls

### DIFF
--- a/share/fry/functions/fry-ls.fish
+++ b/share/fry/functions/fry-ls.fish
@@ -1,4 +1,4 @@
 function fry-ls --description 'List available rubies'
   echo 'system'
-  /usr/bin/env ls -1 $fry_rubies | cat
+  command ls -1 $fry_rubies | cat
 end


### PR DESCRIPTION
I added `env` to the ls line after realizing that I had aliased `ls` to `ls -AFC` which prints color control characters even to a non-tty, preventing fry-ls from finding ruby versions by string match.
