### PR TITLE
Adding Arch Linux package mention in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ Add the following to the `~/.config/fish/config.fish` file:
 . /usr/local/share/fry/fry.fish
 ```
 
+### Arch Linux
+
+`fry` is also available for Arch Linux in the [AUR](https://aur.archlinux.org) as the package [fry](https://aur.archlinux.org/packages/fry/) or [fry-git](https://aur.archlinux.org/packages/fry-git/).
+To install, use your favorite AUR helper (`yoaurt`, `aura`, etc.).
+
+```sh
+$ yoaurt -S fry
+```
+
 ### Rubies
 
 By default `fry` will look for rubies in `~/.rubies`. This can be configured as you like.


### PR DESCRIPTION
I've added two packages for `fry` in Arch. One follows the latest release, the other the `master` branch of this repository :)
