### PR TITLE
fry-current.fish: use type instead of which

### DIFF
--- a/share/fry/functions/fry-current.fish
+++ b/share/fry/functions/fry-current.fish
@@ -29,7 +29,7 @@ function fry-current --description 'Show the current ruby'
   end
 
   if set -ql option_path[1]
-    dirname (which ruby)
+    dirname (type -P ruby)
   else
     echo 'system'
   end


### PR DESCRIPTION
type is a builtin command of fish and therefore faster and more portable.
