### PR TITLE
Fixing errant `which` messages

### DIFF
--- a/share/fry/fry.fish
+++ b/share/fry/fry.fish
@@ -18,7 +18,7 @@ end
 # Installer
 if not set -q fry_installer
   for command in (fry installers)
-    test (which $command); and set -U fry_installer $command
+    type -f $command >/dev/null; and set -U fry_installer $command
   end
 end
 


### PR DESCRIPTION
If `ruby-build` is not installed, `which` spits out error messages to the console on first startup. Switching to the builtin `type` and squelching output avoids a subshell or subprocess and eliminates error messages :)
