### PR TITLE
Fix current for rubinius

### DIFF
--- a/share/fry/functions/fry-current.fish
+++ b/share/fry/functions/fry-current.fish
@@ -17,15 +17,17 @@ function fry-current --description 'Show the current ruby'
 		end
 	end
 
-	for i in $fish_user_paths
-		if test (expr $i : $fry_rubies) -eq 0
+	echo $fry_rubies/(fry-ls)/bin | read -a -l available_ruby_paths
+
+	for p in $fish_user_paths
+		if not contains $p $available_ruby_paths
 			continue
 		end
 
 		if test $show_path -eq 1
-			echo $i
+			echo $p
 		else
-			basename (dirname $i)
+			basename (dirname $p)
 		end
 
 		return

--- a/test/test_fry-current.fish
+++ b/test/test_fry-current.fish
@@ -2,12 +2,19 @@ function suite_fry-current
 	function setup
 		stub_var fry_rubies (stub_dir)
 		mkdir -p $fry_rubies/ruby-2.0/bin
+		mkdir -p $fry_rubies/rbx-2.2.6/bin
+		mkdir -p $fry_rubies/rbx-2.2.6/gems/bin
 	end
 
 	function test_ruby_in_path
 		stub_var fish_user_paths $fry_rubies/ruby-2.0/bin
 		assert (fry-current)
 		assert_equal 'ruby-2.0' (fry-current)
+	end
+
+	function test_skips_ruby_gems_path
+		stub_var fish_user_paths $fry_rubies/rbx-2.2.6/gems/bin $fry_rubies/rbx-2.2.6/bin
+		assert_equal 'rbx-2.2.6' (fry-current)
 	end
 
 	function test_ruby_not_in_path


### PR DESCRIPTION
Since I moved the gempath before the ruby bin path the current functionality
didn't work since it relied on the first ruby found.

This adds a regression test to make sure it doesn't happen again.

Fixes terlar/fry#32
