### PR TITLE
Fix fry installer

### DIFF
--- a/share/fry/fry.fish
+++ b/share/fry/fry.fish
@@ -30,7 +30,7 @@ end
 
 if not set -q fry_installer
 	for command in (fry installers)
-		if type -fq $command
+		if type -f $command >/dev/null
 			set -U fry_installer $command
 		end
 	end

--- a/share/fry/functions/fry-installer-ruby-install.fish
+++ b/share/fry/functions/fry-installer-ruby-install.fish
@@ -12,8 +12,8 @@ function fry-installer-ruby-install --description 'Installer for ruby-install'
 			case '  *:'
 				set implementation (echo $line | sed 's/[[:space:]]*\([[:alpha:]]*\):/\1/')
 
-			case '    *:*'
-				set -l ver (echo $line | sed 's/[[:space:]]*\(.*\):.*/\1/')
+			case '*'
+				set -l ver (echo $line | sed 's/[[:space:]]*\(.*\)$/\1/')
 				echo $implementation-$ver
 			end
 		end


### PR DESCRIPTION
The init script was using newer features in fish that wasn't released in the
release non-nightly versions. This made the installers break.

I also found out the `ruby-install` has updated their output, so the rubies
parsing didn't work anymore.